### PR TITLE
Bumped the version after minor patch in prev commit

### DIFF
--- a/historic_bank_rates.gemspec
+++ b/historic_bank_rates.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name         = 'historic_bank_rates'
-  s.version      = '0.2.0'
+  s.version      = '0.2.1'
   s.platform     = Gem::Platform::RUBY
   s.date         = '2016-06-21'
   s.summary      = 'Scrapes various bank websites to generate a list of

--- a/lib/historic_bank_rates.rb
+++ b/lib/historic_bank_rates.rb
@@ -1,5 +1,5 @@
 require_relative 'historic_bank_rates/rates'
 
 module HistoricBankRates
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
In a previous commit, a patch was deployed to correct the url for the Bank of Tanzania. This PR bumps the gem version so that SolarHub will pull the patched version.
