### PR TITLE
Corrected string mapping for Bank of Tanzania scraper

### DIFF
--- a/historic_bank_rates.gemspec
+++ b/historic_bank_rates.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name         = 'historic_bank_rates'
-  s.version      = '0.2.1'
+  s.version      = '0.2.2'
   s.platform     = Gem::Platform::RUBY
-  s.date         = '2016-06-21'
+  s.date         = '2016-08-01'
   s.summary      = 'Scrapes various bank websites to generate a list of
                     currencies and their historic rates.'
   s.description  = "Wraps a simple scraper to retrieve the historic exchange

--- a/lib/historic_bank_rates.rb
+++ b/lib/historic_bank_rates.rb
@@ -1,5 +1,5 @@
 require_relative 'historic_bank_rates/rates'
 
 module HistoricBankRates
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end

--- a/lib/historic_bank_rates/bank_scrapers/bank_of_tanzania.rb
+++ b/lib/historic_bank_rates/bank_scrapers/bank_of_tanzania.rb
@@ -48,8 +48,8 @@ module HistoricBankRates
 
         Hash[rows.map do |row|
                currency = TRANSLATE[row.css(':nth-child(1) font').text.split.join(' ')]
-               buy = Float(row.css(':nth-child(3) font').text.delete(',', '')) rescue nil
-               sell = Float(row.css(':nth-child(4) font').text.delete(',', '')) rescue nil
+               buy = Float(row.css(':nth-child(3) font').text.delete(',')) rescue nil
+               sell = Float(row.css(':nth-child(4) font').text.delete(',')) rescue nil
                next if currency.nil? || buy.nil? || sell.nil?
 
                # average of by and sell, divide by 100 b/c conversion is given in 100 units

--- a/spec/historic_bank_rates/bank_scrapers/bank_of_tanzania_spec.rb
+++ b/spec/historic_bank_rates/bank_scrapers/bank_of_tanzania_spec.rb
@@ -14,7 +14,7 @@ describe HistoricBankRates::BankScrapers::BankOfTanzania do
     context 'when the scraper is successful', :vcr do
       subject { rate_scraper.call(valid_date) }
       it { should be_a_kind_of(Hash) }
-      it { should include('RWF', 'BFI', 'MWK') }
+      it { should include('RWF', 'BFI', 'MWK', 'EUR', 'USD') }
     end
 
     context 'when the scraper fails', :vcr do
@@ -23,7 +23,7 @@ describe HistoricBankRates::BankScrapers::BankOfTanzania do
       end
       subject { rate_scraper.call(valid_date) }
       it { should be_a_kind_of(Hash) }
-      it { should_not include('RWF', 'BFI', 'MWK') }
+      it { should_not include('RWF', 'BFI', 'MWK', 'EUR', 'USD') }
     end
   end
 


### PR DESCRIPTION
The Bank of Tanzania scraper was unable to remove the commas from the list of currencies. This PR corrects this, adds specs to cover this fail-case and bumps the version.
